### PR TITLE
Crater copying and repeatability

### DIFF
--- a/cratermaker/components/crater/__init__.py
+++ b/cratermaker/components/crater/__init__.py
@@ -746,6 +746,7 @@ class Crater(ComponentBase):
 
             """
             id_args = [
+                "time",
                 "semimajor_axis",
                 "projectile_angle",
                 "location",
@@ -756,9 +757,8 @@ class Crater(ComponentBase):
                 "projectile_mass",
                 "semiminor_axis",
             ]
-            combined_args = [k for k in kwargs if k in id_args]
-            combined_args.sort()  # Sort to ensure consistent ordering
-            combined = "::".join(f"{k}:{kwargs[k]}" for k in combined_args)
+            combined_args = [k for k in id_args if k in kwargs and kwargs[k] is not None]
+            combined = "".join(f"{kwargs[k]}" for k in combined_args)
             hexid = hashlib.shake_256(combined.encode()).hexdigest(4)
             return np.uint32(int(f"0x{hexid}", 16))
 

--- a/cratermaker/components/morphology/__init__.py
+++ b/cratermaker/components/morphology/__init__.py
@@ -180,8 +180,7 @@ class MorphologyCrater(Crater):
                 raise TypeError("relative_location must be a dict with keys 'distance' and 'bearing'.")
             location = morphology.surface.compute_location_from_distance_bearing(**relative_location)
 
-        if crater is None:
-            crater = super().maker(location=location, check_redundant_inputs=check_redundant_inputs, **kwargs)
+        crater = super().maker(crater=crater, location=location, check_redundant_inputs=check_redundant_inputs, **kwargs)
         args = {}
 
         return cls(
@@ -877,6 +876,7 @@ class Morphology(ComponentBase):
                 @classmethod
                 def maker(cls: type[_WrappedMorphologyCrater], **kwargs):
                     kwargs["morphology"] = self
+                    kwargs = {**kwargs, **vars(self.common_args)}
                     return self._CraterType.maker(**kwargs)
 
             self._Crater = _WrappedMorphologyCrater

--- a/cratermaker/components/morphology/basicmoon.py
+++ b/cratermaker/components/morphology/basicmoon.py
@@ -96,8 +96,7 @@ class BasicMoonCrater(MorphologyCrater):
         from cratermaker.components.morphology import Morphology
 
         morphology = Morphology.maker(morphology, **kwargs)
-        if crater is None:
-            crater = super().maker(morphology=morphology, **kwargs)
+        crater = super().maker(crater=crater, morphology=morphology, **kwargs)
         args = {}
         diameter_m = crater.diameter
         diameter_km = diameter_m * 1e-3

--- a/crates/cratermaker-components/Cargo.toml
+++ b/crates/cratermaker-components/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cratermaker-components"
-version = "2026.4.2-a10+gc46afec9d"
+version = "2026.4.4-a0"
 edition = "2021"
 
 

--- a/crates/cratermaker-py/Cargo.toml
+++ b/crates/cratermaker-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cratermaker-py"
-version = "2026.4.2-a10+gc46afec9d"
+version = "2026.4.4-a0"
 edition = "2021"
 
 [lib]

--- a/docs/user-guide/production.rst
+++ b/docs/user-guide/production.rst
@@ -329,10 +329,7 @@ By default, when a list of craters with production metadata is loaded into |prod
 Modifying the Quasi Monte Carlo crater list
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The list of craters stored in |production.quasimc_craters| can be modified at any time. Reprocessing is triggered any time a crater in the list is found without a |crater.time| value. For instance, if you append to the list, the new crater will be added and the list will be reprocessed to extract new |crater.time| values. 
-
-.. 
-   Note that all craters in the list with production metadata will be reprocessed to generate a new |crater.time| value, even if they had one previously. 
+The list of craters stored in |production.quasimc_craters| can be modified at any time. Reprocessing is triggered any time a crater in the list is found without a |crater.time| value. For instance, if you append to the list, the new crater will be added and the list will be reprocessed to extract new |crater.time| values.  Note that all craters in the list with production metadata will be reprocessed to generate a new |crater.time| value, even if they had one previously. 
 
 .. ipython:: python
    :okwarning:

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -3,6 +3,11 @@
 What's New
 ==========
 
+.. _whats-new.2026.4.4-alpha:
+
+- Fixed :issue:`124` :pull:`125` `David Minton`_
+- Fixed a problem where the Simulation's rng was not being passed to the Crater wrapper, so that the simulation.Crater was not producing repeatable results. :pull:`125` `David Minton`_
+- Removed "addopts = tests" option from the pytest.ini addopts so that individual tests can be run rather than always all of them. :pull:`125` `David Minton`_
 
 .. _whats-new.2026.4.3-alpha:
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,4 @@
 [pytest]
-addopts = tests
 filterwarnings =
     ignore::FutureWarning:xarray
     ignore::FutureWarning:uxarray

--- a/tests/core/test_simulation.py
+++ b/tests/core/test_simulation.py
@@ -316,6 +316,54 @@ class TestSimulation(unittest.TestCase):
 
         return
 
+    def test_repeatable_crater_copy(self):
+        """
+        Tests two things: Copied+modified craters retain their old non-modified values and repeated craters called with the same simulation rng_seed are the same.
+        """
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as simdir:
+            crater_vals = []
+            diffs = ["location", "projectile_velocity", "orientation", "id"]
+            sames = ["diameter", "time"]
+            for sim_num in range(2):
+                sim = cratermaker.Simulation(
+                    simdir=simdir, gridlevel=self.gridlevel, ask_overwrite=False, reset=True, rng_seed=2345253
+                )
+
+                for iteration in range(2):
+                    crater = sim.Crater.maker(diameter=5000.0, time=1000.0)
+                    new_crater = sim.Crater.maker(crater=crater, time=2000.0)
+                    crater_dict = crater.as_dict()
+                    crater_vals.append(crater_dict)
+                    new_crater_dict = new_crater.as_dict()
+                    self.assertTrue(
+                        all(
+                            crater_dict[k] != new_crater_dict[k]
+                            if k == "time" or k == "id"
+                            else crater_dict[k] == new_crater_dict[k]
+                            for k in crater_dict
+                        ),
+                        msg=f"Failed for sim_num {sim_num} iteration {iteration}",
+                    )
+
+                self.assertTrue(
+                    all(crater_vals[-2][k] == crater_vals[-1][k] for k in sames),
+                    msg=f"Failed same values check on sim_num {sim_num}",
+                )
+                self.assertTrue(
+                    all(crater_vals[-2][k] != crater_vals[-1][k] for k in diffs),
+                    msg=f"Failed different values check on sim_num {sim_num}",
+                )
+
+            combo = diffs + sames
+            self.assertTrue(
+                all(crater_vals[0][k] == crater_vals[2][k] for k in combo),
+                msg="Failed repeatability of iteration 0 between the two sims",
+            )
+            self.assertTrue(
+                all(crater_vals[1][k] == crater_vals[3][k] for k in combo),
+                msg="Failed repeatability of iteration 1 between the two sims",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- Fixed #124. 
- Fixed a problem where the Simulation's rng was not being passed to the Crater wrapper, so that the simulation.Crater was not producing repeatable results.
- Removed "addopts = tests" option from the pytest.ini addopts so that individual tests can be run rather than always all of them.