### PR TITLE
 Crater.maker() does not use the projectile_density argument as it sh…

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name:  Install OpenSSL OpenBLAS via Homebrew (macOS)
         if: runner.os == 'macOS'
-        run: brew install coreutils gcc openssl@3 openblas
+        run: brew install gdal openssl@3 openblas
 
       - name: Install OpenBLAS via vcpkg (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -41,7 +41,11 @@ jobs:
 
       - name:  Install OpenSSL OpenBLAS via Homebrew (macOS)
         if: runner.os == 'macOS'
-        run: brew install gdal openssl@3 openblas
+        run: |
+          brew install openssl@3 openblas gcc
+          GCC_VER=$(brew list --versions gcc | awk '{print $2}' | cut -d. -f1)
+          GCC_LIB="$(brew --prefix gcc)/lib/gcc/${GCC_VER}"
+          echo "DYLD_LIBRARY_PATH=${GCC_LIB}${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}" >> $GITHUB_ENV
 
       - name: Install OpenBLAS via vcpkg (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name:  Install OpenSSL OpenBLAS via Homebrew (macOS)
         if: runner.os == 'macOS'
-        run: brew install openssl@3 openblas
+        run: brew install coreutils gcc openssl@3 openblas
 
       - name: Install OpenBLAS via vcpkg (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/deploy_wheels.yml
+++ b/.github/workflows/deploy_wheels.yml
@@ -37,7 +37,11 @@ jobs:
 
       - name:  Install OpenSSL OpenBLAS via Homebrew (macOS)
         if: runner.os == 'macOS'
-        run: brew install openssl@3 openblas
+        run: |
+          brew install openssl@3 openblas gcc
+          GCC_VER=$(brew list --versions gcc | awk '{print $2}' | cut -d. -f1)
+          GCC_LIB="$(brew --prefix gcc)/lib/gcc/${GCC_VER}"
+          echo "DYLD_LIBRARY_PATH=${GCC_LIB}${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}" >> $GITHUB_ENV
 
       - name: Install OpenBLAS via vcpkg (Windows)
         if: runner.os == 'Windows'

--- a/cratermaker/components/crater/__init__.py
+++ b/cratermaker/components/crater/__init__.py
@@ -991,7 +991,7 @@ class Crater(ComponentBase):
             projectile = Projectile.maker(
                 projectile,
                 target=target,
-                **kwargs,
+                **{**projectile_args, **kwargs},
             ).new_projectile(
                 **projectile_args,
             )

--- a/cratermaker/components/morphology/__init__.py
+++ b/cratermaker/components/morphology/__init__.py
@@ -32,6 +32,7 @@ from cratermaker.utils.general_utils import parameter
 if TYPE_CHECKING:
     from cratermaker.components.counting import Counting
     from cratermaker.components.production import Production
+    from cratermaker.components.scaling import Scaling
     from cratermaker.components.surface import LocalSurface, Surface
 
 
@@ -180,7 +181,9 @@ class MorphologyCrater(Crater):
                 raise TypeError("relative_location must be a dict with keys 'distance' and 'bearing'.")
             location = morphology.surface.compute_location_from_distance_bearing(**relative_location)
 
-        crater = super().maker(crater=crater, location=location, check_redundant_inputs=check_redundant_inputs, **kwargs)
+        crater = super().maker(
+            crater=crater, scaling=morphology.scaling, location=location, check_redundant_inputs=check_redundant_inputs, **kwargs
+        )
         args = {}
 
         return cls(
@@ -357,6 +360,7 @@ class Morphology(ComponentBase):
         surface: Surface | str | None = None,
         production: Production | str | None = None,
         counting: Counting | str | None = None,
+        scaling: Scaling | str | None = None,
         do_subpixel_degradation: bool = True,
         do_slope_collapse: bool = True,
         do_counting: bool | None = None,
@@ -373,6 +377,8 @@ class Morphology(ComponentBase):
             The name of a Production object, or an instance of Production, to be associated with the morphology model. This is used for subpixel degradation in the emplace method. It is otherwise ignored if do_subpixel_degradation is False.
         counting : str, Counting or None, optional
             The name of a Counting object, or an instance of Counting, to be associated with the morphology model. This is used to record crater counts during emplacement. If None, no counting will be performed.
+        scaling : str, Scaling or None, optional
+            The projectile->crater size scaling model to use from the components library. The default is "montecarlo".
         do_subpixel_degradation : bool, optional
             If True, subpixel degradation will be performed during the emplacement of craters. Default is True.
         do_slope_collapse : bool, optional
@@ -385,11 +391,13 @@ class Morphology(ComponentBase):
         """
         from cratermaker.components.counting import Counting
         from cratermaker.components.production import Production
+        from cratermaker.components.scaling import Scaling
         from cratermaker.components.surface import Surface
 
         super().__init__(**kwargs)
         object.__setattr__(self, "_production", None)
         object.__setattr__(self, "_counting", None)
+        object.__setattr__(self, "_scaling", None)
         object.__setattr__(self, "_do_counting", None)
         object.__setattr__(self, "_excavated_volume", None)
         object.__setattr__(self, "_Crater", None)
@@ -407,6 +415,8 @@ class Morphology(ComponentBase):
             self.counting.morphology = self  # Associated counting and morphology with each other
         else:
             self.counting = Counting.maker(counting, surface=self.surface, morphology=self, **kwargs)
+
+        self.scaling = Scaling.maker(scaling, **kwargs)
 
         if do_counting is not None:
             if do_counting and self.counting is None:
@@ -440,6 +450,7 @@ class Morphology(ComponentBase):
         surface: Surface | str | None = None,
         production: Production | str | None = None,
         counting: Counting | str | None = None,
+        scaling: Scaling | str | None = None,
         do_subpixel_degradation: bool = True,
         do_slope_collapse: bool = True,
         **kwargs: Any,
@@ -457,6 +468,8 @@ class Morphology(ComponentBase):
             The name of a Production object, or an instance of Production, to be associated with the morphology model. This is used for subpixel degradation in the emplace method. It is otherwise ignored.
         counting : str or Counting, optional
             The name of a Counting object, or an instance of Counting, to be associated with the morphology model. This is used to record crater counts during emplacement. If None, no counting will be performed.
+        scaling : str or Scaling or None, optional
+            The projectile->crater size scaling model to use from the components library. The default is "montecarlo".
         do_subpixel_degradation : bool, optional
             If True, subpixel degradation will be performed during the emplacement of craters. Default is True.
         do_slope_collapse : bool, optional
@@ -484,6 +497,7 @@ class Morphology(ComponentBase):
             surface=surface,
             production=production,
             counting=counting,
+            scaling=scaling,
             do_subpixel_degradation=do_subpixel_degradation,
             do_slope_collapse=do_slope_collapse,
             **kwargs,
@@ -862,6 +876,21 @@ class Morphology(ComponentBase):
         if not isinstance(value, bool):
             raise TypeError("do_counting must be a boolean value")
         self._do_counting = value
+
+    @property
+    def scaling(self):
+        """
+        The Scaling object that defines the crater scaling relationships model. Set during initialization.
+        """
+        return self._scaling
+
+    @scaling.setter
+    def scaling(self, value):
+        from cratermaker.components.scaling import Scaling
+
+        if not isinstance(value, Scaling):
+            raise TypeError("scaling must be of Scaling")
+        self._scaling = value
 
     @property
     def _CraterType(self) -> type[MorphologyCrater]:

--- a/cratermaker/components/projectile/__init__.py
+++ b/cratermaker/components/projectile/__init__.py
@@ -230,8 +230,8 @@ class Projectile(ComponentBase):
         from cratermaker.components.projectile.comets import CometProjectiles
         from cratermaker.components.target import Target
 
+        target = Target.maker(target, **kwargs)
         if projectile is None:
-            target = Target.maker(target, **kwargs)
             if target.name in AsteroidProjectiles._catalogue:
                 projectile = "asteroids"
             elif target.name in CometProjectiles._catalogue:
@@ -241,7 +241,14 @@ class Projectile(ComponentBase):
                 mean_velocity = 20.0e3 if mean_velocity is None else mean_velocity
 
         # if this is a brand new uninstantiated projectile, we need to flag it so that it its properties can be set propertly. Otherwise, it should just pass through as is.
-        isfresh = isinstance(projectile, str)
+        isfresh = (
+            isinstance(projectile, str)
+            or velocity is not None
+            or angle is not None
+            or direction is not None
+            or location is not None
+            or density is not None
+        )
 
         projectile = super().maker(
             component=projectile,
@@ -264,6 +271,7 @@ class Projectile(ComponentBase):
                 angle=angle,
                 direction=direction,
                 location=location,
+                density=density,
                 **kwargs,
             )
         else:
@@ -275,6 +283,7 @@ class Projectile(ComponentBase):
         angle: FloatLike | None = None,
         direction: FloatLike | None = None,
         location: tuple[float, float] | None = None,
+        density: FloatLike | None = None,
         **kwargs: Any,
     ) -> Self:
         """
@@ -290,6 +299,8 @@ class Projectile(ComponentBase):
             The impact direction in degrees. Default is 0.0 degrees (due North) if `sample` is False.
         location : tuple[float, float] | None
             The location of the projectile on the target body in (lon, lat) coordinates. If None, the location will be sampled from a distribution.
+        density : float | None
+            The density of the projectile in kg/m³. If None, the density will be the default for this Projectile type.
         **kwargs : Any
             |kwargs|
 
@@ -335,6 +346,9 @@ class Projectile(ComponentBase):
             new_obj._location = mc.get_random_location(rng=new_obj.rng)[0]
         elif new_obj._location is None:
             new_obj._location = (0, 0)
+
+        if density is not None:
+            new_obj.density = density
 
         return new_obj
 

--- a/cratermaker/components/surface/hireslocal.py
+++ b/cratermaker/components/surface/hireslocal.py
@@ -424,7 +424,6 @@ class HiResLocalSurface(Surface):
 
     def set_superdomain(
         self,
-        scaling: Scaling | str | None = None,
         morphology: Morphology | str | None = None,
         reset: bool = False,
         regrid: bool = False,
@@ -437,8 +436,6 @@ class HiResLocalSurface(Surface):
 
         Parameters
         ----------
-        scaling : Scaling | str | None, optional
-            The scaling model to use. If None, the default scaling model will be used.
         morphology : Morphology | str | None, optional
             The morphology model to use. If None, the default morphology model will be used.
         reset : bool, optional
@@ -452,11 +449,10 @@ class HiResLocalSurface(Surface):
 
         from cratermaker import Crater
 
-        scaling = Scaling.maker(scaling, target=self.target, **kwargs)
         morphology = Morphology.maker(morphology, surface=self, target=self.target, **kwargs)
 
         antipode_distance = np.pi * self.target.radius
-        projectile_velocity = scaling.projectile.mean_velocity * 10
+        projectile_velocity = morphology.scaling.projectile.mean_velocity * 10
 
         distance = 1.0
         dvals = []
@@ -468,10 +464,9 @@ class HiResLocalSurface(Surface):
                 np.log10(self.target.radius * 2),
                 1000,
             ):
-                crater = Crater.maker(
+                crater = morphology.Crater.maker(
                     diameter=diameter,
                     angle=90.0,
-                    scaling=scaling,
                     projectile_velocity=projectile_velocity,
                 )
                 rmax = morphology.rmax(crater=crater, minimum_thickness=1e-3)
@@ -495,7 +490,7 @@ class HiResLocalSurface(Surface):
             self._superdomain_function_exponent = 1.0
         self._superdomain_scale_factor = self.superdomain_function(antipode_distance)
 
-        self._load_from_files(reset=reset, regrid=regrid, scaling=scaling, morphology=morphology, **kwargs)
+        self._load_from_files(reset=reset, regrid=regrid, **kwargs)
         return
 
     def set_face_proj(self):

--- a/cratermaker/core/simulation.py
+++ b/cratermaker/core/simulation.py
@@ -211,6 +211,7 @@ class Simulation(CratermakerBase):
             surface=self.surface,
             production=self.production,
             counting=self.counting,
+            scaling=self.scaling,
             **morphology_config,
         )
 
@@ -218,7 +219,6 @@ class Simulation(CratermakerBase):
         # This is because when creating a new Surface object of this type, the grid generation is deferred until the Scaling and Morphology objects are initialized in order to set the superdomain properly.
         if issubclass(self.surface.__class__, HiResLocalSurface) and self.surface.uxgrid is None:
             self.surface.set_superdomain(
-                scaling=self.scaling,
                 morphology=self.morphology,
                 reset=self.is_new,
                 **surface_config,
@@ -786,7 +786,6 @@ class Simulation(CratermakerBase):
                     self.Crater.maker(
                         location=location,
                         time=time,
-                        scaling=self.scaling,
                         **diam_arg,
                         **vars(self.common_args),
                         **kwargs,
@@ -862,8 +861,6 @@ class Simulation(CratermakerBase):
             sim.emplace(craters)
 
         """
-        if craters is None and "scaling" not in kwargs:
-            kwargs["scaling"] = self.scaling
         self.is_new = False
         return self.morphology.emplace(craters=craters, **kwargs)
 
@@ -1435,7 +1432,6 @@ class Simulation(CratermakerBase):
                 projectile_diameter=projectile_diameter,
                 angle=angle,
                 projectile_velocity=projectile_velocity,
-                scaling=scaling,
                 **vars(self.common_args),
             ).diameter
             if limit == "smallest":
@@ -1452,7 +1448,6 @@ class Simulation(CratermakerBase):
                 diameter=crater_diameter,
                 angle=angle,
                 projectile_velocity=projectile_velocity,
-                scaling=scaling,
                 **vars(self.common_args),
             ).projectile_diameter
             return float(projectile_diameter)
@@ -1628,7 +1623,10 @@ class Simulation(CratermakerBase):
             return self.production.diameter_range[0]
         elif self.production.generator_type == "projectile":
             projectile_diameter = self.production.diameter_range[0]
-            return self._get_diameter_limit("smallest", projectile_diameter=projectile_diameter)
+            if projectile_diameter > 0:
+                return self._get_diameter_limit("smallest", projectile_diameter=projectile_diameter)
+            else:
+                return projectile_diameter
 
     @smallest_crater.setter
     def smallest_crater(self, value):
@@ -1659,7 +1657,10 @@ class Simulation(CratermakerBase):
             return self.production.diameter_range[1]
         elif self.production.generator_type == "projectile":
             projectile_diameter = self.production.diameter_range[1]
-            return self._get_diameter_limit("largest", projectile_diameter=projectile_diameter)
+            if not np.isinf(projectile_diameter):
+                return self._get_diameter_limit("largest", projectile_diameter=projectile_diameter)
+            else:
+                return projectile_diameter
 
     @largest_crater.setter
     def largest_crater(self, value):

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -3,6 +3,14 @@
 What's New
 ==========
 
+.. _whats-new.2026.5.0-alpha:
+
+:release:`v2026.5.0-alpha`
+--------------------------
+
+- Fixed :issue:`128` :pull:`129` by ensuring that the Scaling model gets assigned to the Morphology model, and that density can be passed as an argument to the `new_projectile` method. `David Minton`_
+
+
 .. _whats-new.2026.4.4-alpha:
 
 :release:`v2026.4.4-alpha`

--- a/tests/components/test_crater.py
+++ b/tests/components/test_crater.py
@@ -97,6 +97,14 @@ class TestCrater(unittest.TestCase):
         crater2 = crater1.maker(crater1, measured_radius=1100.0)
         self.assertEqual(crater1.id, crater2.id)
 
+    def test_projectile_override(self):
+        """
+        Test for issue #128.
+        """
+        projectile_density = 7000.0
+        meteor_crater = Crater.maker(target="Earth", diameter=1200.0, projectile_density=projectile_density)
+        self.assertAlmostEqual(meteor_crater.projectile_density, projectile_density)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
…ould.

Fixes #128. Morphology now has a component of Scaling so that it doesn't have to be passed explicitly to internal Crater.maker calls.